### PR TITLE
Open Browser on Start

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "run-p start:*",
     "start:hugo": "hugo server -D --watch",
     "start:webpack": "webpack --mode=development --watch",
+    "start:browser": "sleep 1 && open http://localhost:1313/",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Erik Smith",


### PR DESCRIPTION
Opens the local server in a web browser on start. Includes a 1 second pause to give the build process a moment.